### PR TITLE
Force to capitalize the author's name when module is injected.

### DIFF
--- a/lib/OrePAN2/Injector.pm
+++ b/lib/OrePAN2/Injector.pm
@@ -66,10 +66,11 @@ sub inject {
 sub tarpath {
     my ($self, $basename) = @_;
 
+    my $author = uc($self->{author});
     my $tarpath = File::Spec->catfile($self->directory, 'authors', 'id',
-        substr($self->{author}, 0, 1),
-        substr($self->{author}, 0, 2),
-        $self->{author},
+        substr($author, 0, 1),
+        substr($author, 0, 2),
+        $author,
         $basename);
     mkpath(dirname($tarpath));
 

--- a/t/03_inject.t
+++ b/t/03_inject.t
@@ -21,5 +21,15 @@ subtest 'gz' => sub {
     ok -f "$tmpdir/authors/id/M/MI/MIYAGAWA/Acme-YakiniQ-0.01.tar.gz";
 };
 
-done_testing;
+subtest 'author name must be upper case' => sub {
+    my $tmpdir = tempdir(CLEANUP => 1);
 
+    my $injector = OrePAN2::Injector->new(
+        directory => $tmpdir,
+        author => 'upper',
+    );
+    $injector->inject('t/dat/Acme-Foo-0.01.tar.gz');
+    ok -f "$tmpdir/authors/id/U/UP/UPPER/Acme-Foo-0.01.tar.gz";
+};
+
+done_testing;


### PR DESCRIPTION
I think that author name should be composed of upper cases.

If it allows the situation where upper cases and lower cases are intermingled, some operating systems (but it is OS X mostly...) and its users will go mad.

How do you feel about this change?
