### PR TITLE
Removed incorrect explanation in POD

### DIFF
--- a/script/orepan2-inject
+++ b/script/orepan2-inject
@@ -20,9 +20,6 @@ orepan2-inject - Injector
 
 OrePAN2 injector. This module injects your modules into the OrePAN2 DarkPAN repository.
 
-You need to run the orepan2-indexer script after injecting. Index files are
-required for module installation.
-
 =head1 OPTIONS
 
 =over 4


### PR DESCRIPTION
Now you don't need to `orepan2-indexer` after after using `orepan2-inject`. After running `orepan2-inject` the index will be generated, unless `--no-generate-index` is specified.
