### PR TITLE
Fixing `--author` in orepan2-inject

### DIFF
--- a/lib/OrePAN2/Repository.pm
+++ b/lib/OrePAN2/Repository.pm
@@ -62,9 +62,9 @@ sub make_index {
 }
 
 sub inject {
-    my ($self, $stuff) = @_;
+    my ($self, $stuff, $opts) = @_;
 
-    my $tarpath = $self->injector->inject($stuff);
+    my $tarpath = $self->injector->inject($stuff, $opts);
     $self->cache->set($stuff, $tarpath);
 }
 


### PR DESCRIPTION
Before this change:

```
root@dc597dbfd34a:~# rm -rf /darkpan; orepan2-inject --author=asdf Test::Whitespaces /darkpan
Wrote 1 from Test::Whitespaces
[INFO] Could not find useful meta from '/darkpan/authors/id/D/DU/DUMMY/Test-Whitespaces-1.2.1.tar.gz'
[INFO] Scanning for provided modules...
root@dc597dbfd34a:~#
```

After this change:

```
root@dc597dbfd34a:~# rm -rf /darkpan/; perl -Ilib script/orepan2-inject --author=asdf Test::Whitespaces /darkpan
Wrote 1 from Test::Whitespaces
[INFO] Could not find useful meta from '/darkpan/authors/id/A/AS/ASDF/Test-Whitespaces-1.2.1.tar.gz'
[INFO] Scanning for provided modules...
root@dc597dbfd34a:~#
```

The difference is in path where the file is stored.
