### PR TITLE
Added dependency IO::Socket::SSL

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,7 @@ requires 'File::Temp';
 requires 'File::pushd';
 requires 'Getopt::Long', 2.39;
 requires 'HTTP::Tiny';
+requires 'IO::Socket::SSL', 1.42;
 requires 'Parse::LocalDistribution', '0.11';
 requires 'IO::Zlib';
 requires 'Pod::Usage';


### PR DESCRIPTION
`cpanm OrePAN2` is not working on a clean system.

The problem is that one test fails:

```
root@7b1b6b4a453f:/a/OrePAN2-0.32# prove -lv t/06_inject_live.t
t/06_inject_live.t ..
    # Subtest: use MetaCPAN
Cannot fetch https://cpan.metacpan.org/authors/id/O/OA/OALDERS/OrePAN2-0.32.tar.gz(599 Internal Exception)
    # Child (use MetaCPAN) exited without calling finalize()
not ok 1 - use MetaCPAN

#   Failed test 'use MetaCPAN'
#   at /usr/local/share/perl/5.18.2/Test/Builder.pm line 279.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 2 just after 1.
Dubious, test returned 2 (wstat 512, 0x200)
Failed 1/1 subtests

Test Summary Report
-------------------
t/06_inject_live.t (Wstat: 512 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
Files=1, Tests=1,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.27 cusr  0.03 csys =  0.32 CPU)
Result: FAIL
root@7b1b6b4a453f:/a/OrePAN2-0.32#
```

It fails because HTTP::Tiny is not able to download file. Here is the `$response` from HTTP::Tiny:

```
$VAR1 = {
          'reason' => 'Internal Exception',
          'status' => 599,
          'headers' => {
                         'content-length' => 57,
                         'content-type' => 'text/plain'
                       },
          'url' => 'https://cpan.metacpan.org/authors/id/O/OA/OALDERS/OrePAN2-0.32.tar.gz',
          'success' => '',
          'content' => 'IO::Socket::SSL 1.42 must be installed for https support
'
        };
```

So this patch fixes this problem.
