### PR TITLE
accept code reference as an author parameter

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl extension OrePAN2
 
 {{$NEXT}}
 
+    - [BETA] author attribute accepts a code reference,
+      so that you can calculate author whenever injecting distributions (skaji)
+
 0.36 2015-02-09T21:06:09Z
     - Add OrePAN2::Auditor (oalders)
 

--- a/lib/OrePAN2/Injector.pm
+++ b/lib/OrePAN2/Injector.pm
@@ -240,3 +240,136 @@ sub _run {
 
 1;
 
+__END__
+
+=encoding utf-8
+
+=for stopwords DarkPAN orepan2-inject orepan2-indexer darkpan OrePAN1 OrePAN
+
+=head1 NAME
+
+OrePAN2::Injector - Inject a distribution to your darkpan
+
+=head1 SYNOPSIS
+
+    use OrePAN2::Injector;
+
+    my $injector = OrePAN2::Injector->new(directory => '/path/to/darkpan')
+
+    $injector->inject(
+        'http://cpan.metacpan.org/authors/id/M/MA/MAHITO/Acme-Hoge-0.03.tar.gz',
+        { author => 'MAHITO' },
+    );
+
+=head1 DESCRIPTION
+
+OrePAN2::Injector allows you to inject a distribution to your darkpan.
+
+=head1 METHODS
+
+=head3 C<< my $injector = OrePAN2::Injector->new(%attr) >>
+
+Constructor. Here C<%attr> might be:
+
+=over 4
+
+=item * directory
+
+Your darkpan directory path. This is required.
+
+=item * author
+
+Default author of distributions.
+If you omit this, then C<DUMMY> will be used.
+
+B<BETA>: As of OrePAN2 0.37,
+the author attribute accepts a code reference, so that
+you can calculate author whenever injecting distributions:
+
+    my $author_cb = sub {
+        my $source = shift;
+        $source =~ m{authors/id/./../([^/]+)} ? $1 : "DUMMY";
+    };
+
+    my $injector = OrePAN2::Injector->new(
+        directory => '/path/to/darkpan',
+        author => $author_cb,
+    );
+
+    $injector->inject(
+        'http://cpan.metacpan.org/authors/id/M/MA/MAHITO/Acme-Hoge-0.03.tar.gz'
+    );
+    #=> Acme-Hoge-0.03 will be indexed with author MAHITO
+
+Note that the code reference C<$author_cb> will be executed
+under the following circumstances:
+
+    * the first aurgumet of it is the $source argument of inject method
+    * the working directory of it is the top of the distribution in the question
+
+=back
+
+=head3 C<< $injector->inject($source, \%option) >>
+
+Inject C<$source> to your darkpan. Here C<$source> is one of the following:
+
+=over 4
+
+=item * local archive file
+
+eg: /path/to/Text-TestBase-0.10.tar.gz
+
+=item * http url
+
+eg: http://cpan.metacpan.org/authors/id/T/TO/TOKUHIROM/Text-TestBase-0.10.tar.gz
+
+=item * git repository
+
+eg: git://github.com/tokuhirom/Text-TestBase.git@master
+
+Note that you need to set up git repository as a installable git repo,
+that is, you need to put a META.json in your repository.
+
+If you are using L<Minilla> or L<Milla>, your repository is already ready to install.
+
+Supports the following URL types:
+
+    git+file://path/to/repo.git
+    git://github.com/plack/Plack.git@1.0000        # tag
+    git://github.com/plack/Plack.git@devel         # branch
+
+They are compatible with L<cpanm>.
+
+=item * module name
+
+eg: Data::Dumper
+
+=back
+
+C<\%option> might be:
+
+=over 4
+
+=item * author
+
+Author of distribution. This overwrites C<new>'s author attribute.
+
+=back
+
+=head1 SEE ALSO
+
+L<orepan2-inject>
+
+=head1 LICENSE
+
+Copyright (C) tokuhirom.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+tokuhirom E<lt>tokuhirom@gmail.comE<gt>
+
+=cut
+

--- a/t/03_inject.t
+++ b/t/03_inject.t
@@ -44,4 +44,22 @@ subtest 'check that $self->{author} is used' => sub {
     ok -f "$tmpdir/authors/id/M/MI/MIYAGAWA/Acme-Foo-0.01.tar.gz";
 };
 
+subtest 'check that code reference $self->{author} works' => sub {
+    my $tmpdir = tempdir( CLEANUP => 1 );
+
+    my $injector = OrePAN2::Injector->new(
+        directory => $tmpdir,
+        author    => sub {
+            my $file = shift;
+            require CPAN::Meta;
+            my $meta = CPAN::Meta->load_file("META.json");
+            my $author = $meta->{author}[0]; # tokuhirom <tokuhirom@gmail.com>
+            $author =~ s/\s.*//;
+            uc $author;
+        },
+    );
+    $injector->inject('t/dat/Acme-Foo-0.01.tar.gz');
+    ok -f "$tmpdir/authors/id/T/TO/TOKUHIROM/Acme-Foo-0.01.tar.gz";
+};
+
 done_testing;

--- a/t/06_inject_live.t
+++ b/t/06_inject_live.t
@@ -74,6 +74,25 @@ subtest 'Upgrade undef versions' => sub {
     }
 };
 
+subtest 'code reference author with inject from http works' => sub {
+    my $tmpdir = tempdir( CLEANUP => 1 );
+    my $author = sub {
+        my $source = shift;
+        if ( $source =~ m{authors/id/./../([^/]+)} ) {
+            return $1;
+        } else {
+            die "unexpected";
+        }
+    };
+    my $injector = OrePAN2::Injector->new( directory => $tmpdir );
+    $injector->inject(
+        'https://cpan.metacpan.org/authors/id/O/OA/OALDERS/OrePAN2-0.32.tar.gz',
+        { author => $author },
+    );
+    ok -f "$tmpdir/authors/id/O/OA/OALDERS/OrePAN2-0.32.tar.gz",
+        "detect author by url";
+};
+
 sub inject_and_index {
     my $dir     = shift;
     my $archive = shift;

--- a/t/cli/inject-git.t
+++ b/t/cli/inject-git.t
@@ -41,4 +41,17 @@ subtest 'inject-git' => sub {
     ok -f 'authors/id/D/DU/DUMMY/Acme-YakiniQ-0.01.tar.gz', "inject from git";
 };
 
+subtest 'inject-git with code reference author' => sub {
+    my $tmpdir = pushd( tempdir CLEANUP => 1 );
+    my $injector = OrePAN2::Injector->new(
+        directory => '.',
+    );
+    $injector->inject("git+file://$gitrepo", {
+        author => sub { "MIYAGAWA" },
+    });
+
+    ok -f 'authors/id/M/MI/MIYAGAWA/Acme-YakiniQ-0.01.tar.gz',
+        "code reference author";
+};
+
 done_testing;


### PR DESCRIPTION
from #34 

This patch makes OrePAN2::Injector's new or inject methods allow code reference as an author parameter.
As described in #34, the code reference will be executed with
* the arguments of it are `my ($source) = @_` (here `$source` is a argument of inject() method)
* the working directory is the top of the distribution