### PR TITLE
enable injecting development versions

### DIFF
--- a/lib/OrePAN2/CLI/Indexer.pm
+++ b/lib/OrePAN2/CLI/Indexer.pm
@@ -20,14 +20,16 @@ sub run {
     my $version;
     my $text;
     my $metacpan;
+    my $allow_dev;
 
     my $p = Getopt::Long::Parser->new(
         config => [qw(posix_default no_ignore_case auto_help)] );
     $p->getoptionsfromarray(
         \@args => (
-            'metacpan!' => \$metacpan,
-            'version!'  => \$version,
-            'text!'     => \$text,
+            'metacpan!'  => \$metacpan,
+            'version!'   => \$version,
+            'text!'      => \$text,
+            'allow-dev!' => \$allow_dev,
         )
     );
     if ($version) {
@@ -40,6 +42,7 @@ sub run {
     my $orepan = OrePAN2::Indexer->new(
         directory => $directory,
         metacpan  => $metacpan,
+        allow_dev => $allow_dev,
     );
     $orepan->make_index(
         no_compress => $text,

--- a/lib/OrePAN2/CLI/Inject.pm
+++ b/lib/OrePAN2/CLI/Inject.pm
@@ -25,6 +25,7 @@ sub run {
     my $simple;
     my $text;
     my $enable_cache = 0;
+    my $allow_dev    = 0;
     my $p            = Getopt::Long::Parser->new(
         config => [qw(posix_default no_ignore_case auto_help)] );
     $p->getoptions(
@@ -34,6 +35,7 @@ sub run {
         'simple!'         => \$simple,
         'text!'           => \$text,
         'cache!'          => \$enable_cache,
+        'allow-dev!'      => \$allow_dev,
     );
 
     if ($version) {
@@ -47,6 +49,7 @@ sub run {
         directory      => $directory,
         compress_index => !$text,
         simple         => $simple,
+        allow_dev      => $allow_dev,
     );
     if (@ARGV) {
         for (@ARGV) {

--- a/lib/OrePAN2/Indexer.pm
+++ b/lib/OrePAN2/Indexer.pm
@@ -62,7 +62,7 @@ sub add_index {
     return if $self->_maybe_index_from_metacpan( $index, $archive_file );
 
     my $archive = Archive::Extract->new( archive => $archive_file );
-    my $tmpdir = tempdir( CLEANUP => 1 );
+    my $tmpdir = tempdir('orepan2.XXXXXX', TMPDIR => 1, CLEANUP => 1 );
     $archive->extract( to => $tmpdir );
 
     my $provides = $self->scan_provides( $tmpdir, $archive_file );

--- a/lib/OrePAN2/Indexer.pm
+++ b/lib/OrePAN2/Indexer.pm
@@ -31,6 +31,7 @@ sub new {
 }
 
 sub directory { shift->{directory} }
+sub allow_dev { shift->{allow_dev} }
 
 sub make_index {
     my ( $self, %args ) = @_;
@@ -190,7 +191,10 @@ sub do_metacpan_lookup {
 sub _scan_provides {
     my ( $self, $dir, $meta ) = @_;
 
-    my $provides = Parse::LocalDistribution->new->parse($dir);
+    my $provides = Parse::LocalDistribution
+        ->new({ ALLOW_DEV_VERSION => $self->allow_dev })
+        ->parse($dir)
+        ;
     return $provides;
 }
 

--- a/lib/OrePAN2/Repository.pm
+++ b/lib/OrePAN2/Repository.pm
@@ -47,6 +47,7 @@ sub indexer {
     $self->{indexer} ||= OrePAN2::Indexer->new(
         directory => $self->directory,
         simple    => $self->{simple},
+        allow_dev => $self->allow_dev,
     );
 }
 
@@ -59,7 +60,6 @@ sub make_index {
     my $self = shift;
     $self->indexer->make_index(
         no_compress => !$self->compress_index,
-        allow_dev   => $self->allow_dev,
     );
 }
 

--- a/lib/OrePAN2/Repository.pm
+++ b/lib/OrePAN2/Repository.pm
@@ -7,7 +7,7 @@ use 5.008_001;
 
 use Carp;
 use Class::Accessor::Lite 0.05 (
-    rw => [qw(directory cache compress_index)],
+    rw => [qw(directory cache compress_index allow_dev)],
 );
 use File::Find;
 use File::Spec;
@@ -57,7 +57,10 @@ sub has_cache {
 
 sub make_index {
     my $self = shift;
-    $self->indexer->make_index( no_compress => !$self->compress_index );
+    $self->indexer->make_index(
+        no_compress => !$self->compress_index,
+        allow_dev   => $self->allow_dev,
+    );
 }
 
 sub inject {


### PR DESCRIPTION
This pokes Parse::LocalDistribution in the correct way to get it indexing
development versions (e.g. 0.01_01).  It also adds --allow-dev (though doesn't
document it at the moment).

This is at least a partial fix to issue #22.