### PR TITLE
If --author contains other path elements do not change the case on th…

### DIFF
--- a/lib/OrePAN2/Injector.pm
+++ b/lib/OrePAN2/Injector.pm
@@ -81,12 +81,14 @@ sub inject {
 sub tarpath {
     my ( $self, $basename ) = @_;
 
-    my $author  = uc( $self->{author} );
+    my( $author, @extra ) = split /\//, $self->{author};
+    $author = uc( $author );
     my $tarpath = File::Spec->catfile(
         $self->directory, 'authors', 'id',
         substr( $author, 0, 1 ),
         substr( $author, 0, 2 ),
         $author,
+        @extra,
         $basename
     );
     mkpath( dirname($tarpath) );


### PR DESCRIPTION
…ose elements.

f.e. if --author=AUTHOR/modules write the file to
A/AU/AUTHOR/modules/<file> instead of A/AU/AUTHOR/MODULES/<file>.