### PR TITLE
rewrite 2 cases of autoderef.

### DIFF
--- a/lib/OrePAN2/Index.pm
+++ b/lib/OrePAN2/Index.pm
@@ -109,7 +109,7 @@ sub as_string {
         '',
         );
 
-    for my $pkg ( $self->packages ) {
+    for my $pkg (@{ $self->packages }) {
         my $entry = $self->{index}{$pkg};
 
         # package name, version, path

--- a/lib/OrePAN2/Index.pm
+++ b/lib/OrePAN2/Index.pm
@@ -109,7 +109,7 @@ sub as_string {
         '',
         );
 
-    for my $pkg (@{ $self->packages }) {
+    for my $pkg (@{ $self->packages ||[]}) {
         my $entry = $self->{index}{$pkg};
 
         # package name, version, path

--- a/lib/OrePAN2/Repository.pm
+++ b/lib/OrePAN2/Repository.pm
@@ -96,7 +96,7 @@ sub gc {
 
     my $index = $self->load_index;
     my %registered;
-    for my $package (@{ $index->packages }) {
+    for my $package (@{ $index->packages ||[]}) {
         my ( $version, $path ) = $index->lookup($package);
         $registered{$path}++;
     }

--- a/lib/OrePAN2/Repository.pm
+++ b/lib/OrePAN2/Repository.pm
@@ -96,7 +96,7 @@ sub gc {
 
     my $index = $self->load_index;
     my %registered;
-    for my $package ( $index->packages ) {
+    for my $package (@{ $index->packages }) {
         my ( $version, $path ) = $index->lookup($package);
         $registered{$path}++;
     }


### PR DESCRIPTION
I found 2 cases of autoderef in here and it's probably better to change them to the good-old circumfix `@{}` . :)
