### PR TITLE
Fix OrePAN2 tests on perl 5.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,7 @@ addons:
       - aspell
       - aspell-en
 before_install:
-  - 'cpanm --notest App::cpm'
   - 'eval $(curl https://travis-perl.github.io/init) --auto'
-  - 'AUTHOR_TESTING=0 cpm install --workers $(test-jobs) --global Code::TidyAll::Plugin::SortLines::Naturally Code::TidyAll::Plugin::UniqueLines Perl::Tidy'
-cache:
-  directories:
-    - '~/perl5'
-install:
-  - 'cpan-install --coverage   # installs coverage prereqs, if enabled'
-  - 'AUTHOR_TESTING=0 cpm install --cpanfile cpanfile --workers $(test-jobs) --global --with-recommends --with-suggests --with-configure --with-develop'
 language: perl
 matrix:
   allow_failures:
@@ -26,11 +18,13 @@ matrix:
       perl: '5.28'
 notifications:
   email:
+    if: repo = "tokuhirom/OrePAN2"
     on_failure: always
     on_success: always
     recipients:
       - olaf@wundersolutions.com
 perl:
+  - '5.10.0'
   - '5.10'
   - '5.12'
   - '5.14'
@@ -41,6 +35,3 @@ perl:
   - '5.24'
   - '5.26'
   - '5.28'
-script:
-  - 'prove -lr -j$(test-jobs) t'
-sudo: 'false'

--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ requires 'perl', '5.008001';
 requires 'autodie';
 
 requires 'Archive::Extract', 0.72;
-requires 'Archive::Tar';
+requires 'Archive::Tar', 1.46;
 requires 'CPAN::Meta', 2.131560;
 requires 'Class::Accessor::Lite', '0.05';
 requires 'Digest::MD5';

--- a/cpanfile
+++ b/cpanfile
@@ -31,6 +31,7 @@ requires 'Ref::Util';
 requires 'Try::Tiny';
 requires 'Type::Params';
 requires 'Types::URI';
+requires 'feature';
 requires 'parent';
 requires 'version', '0.9912';
 
@@ -38,6 +39,7 @@ on 'test' => sub {
     requires 'File::Touch';
     requires 'File::Which';
     requires 'PAUSE::Packages';
+    requires 'Path::Class';
     requires 'Test::More', '0.98';
     requires 'Test::RequiresInternet', '0.02';
 };

--- a/lib/OrePAN2/Index.pm
+++ b/lib/OrePAN2/Index.pm
@@ -7,6 +7,7 @@ use utf8;
 
 use IO::Uncompress::Gunzip ('$GunzipError');
 use OrePAN2;
+use version 0.9912;
 
 sub new {
     my $class = shift;


### PR DESCRIPTION
Hi,

I have added a missing `use` and a version constraint which make OrePAN2 work on perl 5.10.0. I've also tweaked .travis.yml to work for me and also added a couple of dependencies which Kwalitee was complaining about.

All the best,
Dave