### PR TITLE
weaken type constraint of "directory" attribute

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -47,8 +47,7 @@ on 'runtime' => sub {
 on 'test' => sub {
     requires 'File::Touch'            => '0';
     requires 'File::Which'            => '0';
-    requires 'PAUSE::Packages'        => '0';
-    requires 'Path::Class'            => '0';
+    requires 'Path::Tiny'             => '0.119';
     requires 'Test::More'             => '0.98';
     requires 'Test::RequiresInternet' => '0.02';
 };

--- a/cpanfile
+++ b/cpanfile
@@ -35,6 +35,7 @@ on 'runtime' => sub {
     requires 'Pod::Usage'                  => '0';
     requires 'Try::Tiny'                   => '0';
     requires 'Type::Tiny'                  => '2.000000';
+    requires 'Types::Path::Tiny'           => '0';
     requires 'Types::Self'                 => '0';
     requires 'Types::URI'                  => '0';
     requires 'feature'                     => '0';

--- a/lib/OrePAN2/Indexer.pm
+++ b/lib/OrePAN2/Indexer.pm
@@ -22,11 +22,12 @@ use Type::Params             qw( signature );
 use Types::Standard          qw( Bool HashRef Str is_ArrayRef );
 use Types::Common::Numeric   qw( PositiveInt );
 use Types::Self              qw( Self );
+use Types::Path::Tiny        qw( Path );
 
 use namespace::clean;
 
 #<<<
-has directory            => ( is => 'ro', isa => Str,         required => 1 );
+has directory            => ( is => 'ro', isa => Path,        coerce => 1, required => 1 );
 has simple               => ( is => 'ro', isa => Bool,        default  => !!0 );
 has metacpan             => ( is => 'ro', isa => Bool,        default  => !!0 );
 has metacpan_lookup_size => ( is => 'ro', isa => PositiveInt, default => 200 );

--- a/lib/OrePAN2/Injector.pm
+++ b/lib/OrePAN2/Injector.pm
@@ -4,24 +4,25 @@ use utf8;
 
 use Moo;
 
-use Archive::Extract ();
-use Archive::Tar     qw( COMPRESS_GZIP );
-use CPAN::Meta       ();
-use File::Basename   qw( basename dirname );
-use File::Copy       qw( copy );
-use File::Find       qw( find );
-use File::Path       qw( mkpath );
-use File::Spec       ();
-use File::Temp       qw( tempdir );
-use File::pushd      qw( pushd );
-use HTTP::Tiny       ();
-use MetaCPAN::Client ();
-use Types::Standard  qw( CodeRef Str );
+use Archive::Extract  ();
+use Archive::Tar      qw( COMPRESS_GZIP );
+use CPAN::Meta        ();
+use File::Basename    qw( basename dirname );
+use File::Copy        qw( copy );
+use File::Find        qw( find );
+use File::Path        qw( mkpath );
+use File::Spec        ();
+use File::Temp        qw( tempdir );
+use File::pushd       qw( pushd );
+use HTTP::Tiny        ();
+use MetaCPAN::Client  ();
+use Types::Standard   qw( CodeRef Str );
+use Types::Path::Tiny qw( Path );
 
 use namespace::clean;
 
 has author => ( is => 'ro', isa => CodeRef | Str, default => 'DUMMY' );
-has directory => ( is => 'ro', isa => Str, required => 1 );
+has directory => ( is => 'ro', isa => Path, coerce => 1, required => 1 );
 
 sub inject {
     my ( $self, $source, $opts ) = @_;

--- a/lib/OrePAN2/Repository.pm
+++ b/lib/OrePAN2/Repository.pm
@@ -11,13 +11,14 @@ use OrePAN2::Indexer           ();
 use OrePAN2::Injector          ();
 use OrePAN2::Repository::Cache ();
 use Types::Standard            qw( Bool InstanceOf Str );
+use Types::Path::Tiny          qw( Path );
 
 use namespace::clean;
 
 #<<<
 has compress_index => ( is => 'ro',   isa => Bool, default => !!1 );
 has cache          => ( is => 'lazy', isa => InstanceOf ['OrePAN2::Repository::Cache'], builder => 1, handles => { has_cache => 'is_hit', save_cache => 'save' } );
-has directory      => ( is => 'ro',   isa => Str, required => 1 );
+has directory      => ( is => 'ro',   isa => Path, coerce => 1, required => 1 );
 has indexer        => ( is => 'lazy', isa => InstanceOf ['OrePAN2::Indexer'],           builder => 1 );
 has injector       => ( is => 'lazy', isa => InstanceOf ['OrePAN2::Injector'],          builder => 1 );
 has simple         => ( is => 'ro',   isa => Bool, default => !!0 );

--- a/lib/OrePAN2/Repository/Cache.pm
+++ b/lib/OrePAN2/Repository/Cache.pm
@@ -12,13 +12,14 @@ use File::stat             qw( stat );
 use IO::File::AtomicChange ();
 use JSON::PP               ();
 use Types::Standard        qw( Bool HashRef Str );
+use Types::Path::Tiny      qw( Path );
 
 use namespace::clean;
 
-has directory => ( is => 'ro',   isa => Str,     required => 1 );
-has data      => ( is => 'lazy', isa => HashRef, builder  => 1 );
-has filename  => ( is => 'lazy', isa => Str,     builder  => 1 );
-has is_dirty  => ( is => 'rw',   isa => Bool,    default  => !!0 );
+has directory => ( is => 'ro',   isa => Path,    coerce => 1, required => 1 );
+has data      => ( is => 'lazy', isa => HashRef, builder => 1 );
+has filename  => ( is => 'lazy', isa => Str,     builder => 1 );
+has is_dirty  => ( is => 'rw',   isa => Bool,    default => !!0 );
 
 sub _build_data {
     my $self = shift;

--- a/t/01_indexer.t
+++ b/t/01_indexer.t
@@ -9,11 +9,12 @@ use Local::Util qw( slurp slurp_gz );
 use File::Temp  qw( tempdir );
 use File::Path  qw( mkpath );
 use File::Copy  qw( copy );
+use Path::Tiny  qw();
 
 use OrePAN2::Indexer ();
 
 subtest 'gz' => sub {
-    my $tmpdir = tempdir( CLEANUP => 1 );
+    my $tmpdir = Path::Tiny->tempdir( CLEANUP => 1 );
 
     mkpath "$tmpdir/authors/id/M/MI/MIYAGAWA/";
 

--- a/t/03_inject.t
+++ b/t/03_inject.t
@@ -7,11 +7,12 @@ use lib 't/lib';
 use Test::More;
 use Test::More;
 use File::Temp qw( tempdir );
+use Path::Tiny qw();
 
 use OrePAN2::Injector ();
 
 subtest 'gz' => sub {
-    my $tmpdir = tempdir( CLEANUP => 1 );
+    my $tmpdir = Path::Tiny->tempdir( CLEANUP => 1 );
 
     my $injector = OrePAN2::Injector->new(
         directory => $tmpdir,

--- a/t/04_repository.t
+++ b/t/04_repository.t
@@ -4,11 +4,12 @@ use utf8;
 
 use lib 't/lib';
 
-use File::Temp          ();
-use File::Touch         qw( touch );
-use Local::Util         qw( slurp_gz );
-use OrePAN2::Repository ();
 use Test::More;
+use File::Touch qw( touch );
+use Local::Util qw( slurp_gz );
+use Path::Tiny  qw();
+
+use OrePAN2::Repository ();
 
 {
     my ( $repo, $tmpdir ) = make_repo();
@@ -28,7 +29,7 @@ use Test::More;
 }
 
 sub make_repo {
-    my $tmpdir = File::Temp::tempdir( CLEANUP => 1 );
+    my $tmpdir = Path::Tiny->tempdir( CLEANUP => 1 );
 
     my $repo = OrePAN2::Repository->new( directory => $tmpdir, simple => 1 );
     $repo->inject('t/dat/Acme-Foo-0.01.tar.gz');


### PR DESCRIPTION
This should fix the issue #68. For all the classes that have a `directory` attribute the `isa` type constraint was changed from `Str` (belonging to `Types::Standard`) to `Path` (belong to `Types::Path::Tiny`) and coercion was enabled.