### PR TITLE
introduce logging flexibility to OrePAN2

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,6 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - "5.12"
           - "5.14"
           - "5.16"
           - "5.18"
@@ -50,6 +49,8 @@ jobs:
           - "5.34"
           - "5.36"
           - "5.38"
+          - "5.40"
+          - "5.42"
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
     steps:
@@ -69,7 +70,6 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
-          - "5.12"
           - "5.14"
           - "5.16"
           - "5.18"
@@ -83,6 +83,8 @@ jobs:
           - "5.34"
           - "5.36"
           - "5.38"
+          - "5.40"
+          - "5.42"
     name: Perl ${{ matrix.perl-version }} on macos-latest
     needs: build
     steps:

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension OrePAN2
 
 {{$NEXT}}
     - make logging use a real logger object, (GH#18)
+    - Minimum Perl has been bumped from 5.012000 to 5.014000 because of a dependency on IO::Socket::IP
+    - fix test to use https://github.com/ not git://
 
 0.52 2024-02-19T22:27:12Z
     - weaken type constraint of "directory" attribute (GH#69) (XSven)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension OrePAN2
 
 {{$NEXT}}
+    - make logging use a real logger object, (GH#18)
 
 0.52 2024-02-19T22:27:12Z
     - weaken type constraint of "directory" attribute (GH#69) (XSven)

--- a/cpanfile
+++ b/cpanfile
@@ -45,13 +45,14 @@ on 'runtime' => sub {
 };
 
 on 'test' => sub {
-    requires 'File::Touch'            => '0';
-    requires 'File::Which'            => '0';
-    requires 'Path::Tiny'             => '0.119';
-    requires 'Test::More'             => '0.98';
+    requires 'File::Touch' => '0';
+    requires 'File::Which' => '0';
+    requires 'Path::Tiny'  => '0.119';
+    requires 'Test::More'  => '0.98';
+    requires 'Test::Needs' => '0';
+    suggests 'Test::Output' => '0';
     requires 'Test::RequiresInternet' => '0.02';
-    requires 'Capture::Tiny'          => '0';
-    requires 'Log::Any'               => '0';
+    suggests 'Log::Any' => '0';
 };
 
 on 'develop' => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 on 'runtime' => sub {
-    requires 'perl'    => '5.012000';
+    requires 'perl'    => '5.014000';
     requires 'autodie' => '0';
 
     requires 'Archive::Extract'            => '0.72';
@@ -50,9 +50,8 @@ on 'test' => sub {
     requires 'Path::Tiny'             => '0.119';
     requires 'Test::More'             => '0.98';
     requires 'Test::RequiresInternet' => '0.02';
-    suggests 'Capture::Tiny'  => '0';
-    suggests 'Log::Any::Test' => '0';
-    suggests 'Mojo::Log'      => '0';
+    requires 'Capture::Tiny'          => '0';
+    requires 'Log::Any'               => '0';
 };
 
 on 'develop' => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -50,6 +50,9 @@ on 'test' => sub {
     requires 'Path::Tiny'             => '0.119';
     requires 'Test::More'             => '0.98';
     requires 'Test::RequiresInternet' => '0.02';
+    suggests 'Capture::Tiny'  => '0';
+    suggests 'Log::Any::Test' => '0';
+    suggests 'Mojo::Log'      => '0';
 };
 
 on 'develop' => sub {

--- a/lib/OrePAN2.pm
+++ b/lib/OrePAN2.pm
@@ -2,7 +2,7 @@ package OrePAN2;
 use strict;
 use warnings;
 
-our $VERSION = "0.53-dev1";
+our $VERSION = "0.52";
 
 1;
 __END__

--- a/lib/OrePAN2.pm
+++ b/lib/OrePAN2.pm
@@ -2,7 +2,7 @@ package OrePAN2;
 use strict;
 use warnings;
 
-our $VERSION = "0.52";
+our $VERSION = "0.53-dev1";
 
 1;
 __END__

--- a/lib/OrePAN2/Index.pm
+++ b/lib/OrePAN2/Index.pm
@@ -6,6 +6,7 @@ use utf8;
 use IO::Uncompress::Gunzip qw( $GunzipError );
 use OrePAN2                ();
 use version;
+use OrePAN2::Logger;
 
 use Moo;
 use Types::Standard qw( HashRef );
@@ -72,9 +73,9 @@ sub add_index {
 
         if ( version->parse($orig_ver) > version->parse($version) ) {
             $version //= 'undef';
-            print STDERR "[INFO] Not adding $package in $archive_file\n";
-            print STDERR
-                "[INFO] Existing version $orig_ver is greater than $version\n";
+            $self->log->info("Not adding $package in $archive_file");
+            $self->log->info(
+                "Existing version $orig_ver is greater than $version");
             return;
         }
     }
@@ -114,6 +115,13 @@ sub as_string {
     }
     return join( "\n", @buf ) . "\n";
 }
+
+#@type OrePAN2::Logger
+has log => (
+    is      => 'ro',
+    lazy    => 1,
+    default => sub { my ($self) = @_; OrePAN2::Logger->new->get_logger() }
+);
 
 1;
 __END__

--- a/lib/OrePAN2/Index.pm
+++ b/lib/OrePAN2/Index.pm
@@ -9,6 +9,7 @@ use version;
 use OrePAN2::Logger;
 
 use Moo;
+with 'OrePAN2::Role::HasLogger';
 use Types::Standard qw( HashRef );
 use namespace::clean;
 
@@ -115,13 +116,6 @@ sub as_string {
     }
     return join( "\n", @buf ) . "\n";
 }
-
-#@type OrePAN2::Logger
-has log => (
-    is      => 'ro',
-    lazy    => 1,
-    default => sub { my ($self) = @_; OrePAN2::Logger->new->get_logger() }
-);
 
 1;
 __END__

--- a/lib/OrePAN2/Logger.pm
+++ b/lib/OrePAN2/Logger.pm
@@ -1,0 +1,22 @@
+package OrePAN2::Logger;
+use strict;
+use warnings;
+
+use Moo;
+use namespace::clean;
+
+has log => ( is => 'ro', writer => '_set_log' );
+
+sub get_logger {
+    my ($self) = @_;
+    $self->_set_log( bless {}, 'OrePAN2::Logger' );
+    return ( $self->log );
+}
+
+#sub warn { shift; print STDERR "[WARN] $_[0]\n" }
+sub info { shift; print STDERR "[INFO] $_[0]\n" }
+
+#sub debug { shift; print STDERR "[DEBUG] $_[0]\n" }
+#sub error { shift; print STDERR "[ERROR] $_[0]\n" }
+
+1;

--- a/lib/OrePAN2/Logger.pm
+++ b/lib/OrePAN2/Logger.pm
@@ -13,10 +13,18 @@ sub get_logger {
     return ( $self->log );
 }
 
-#sub warn { shift; print STDERR "[WARN] $_[0]\n" }
+# trace
+# debug
+# info (inform)
 sub info { shift; print STDERR "[INFO] $_[0]\n" }
 
-#sub debug { shift; print STDERR "[DEBUG] $_[0]\n" }
-#sub error { shift; print STDERR "[ERROR] $_[0]\n" }
+# notice
+# warning (warn)
+sub warn { shift; print STDERR "[WARN] $_[0]\n" }
+
+# error (err)
+# critical (crit, fatal)
+# alert
+# emergency
 
 1;

--- a/lib/OrePAN2/Logger.pm
+++ b/lib/OrePAN2/Logger.pm
@@ -1,26 +1,15 @@
 package OrePAN2::Logger;
-use strict;
-use warnings;
 
 use Moo;
-use namespace::clean;
-
-has log => ( is => 'ro', writer => '_set_log' );
-
-sub get_logger {
-    my ($self) = @_;
-    $self->_set_log( bless {}, 'OrePAN2::Logger' );
-    return ( $self->log );
-}
 
 # trace
 # debug
 # info (inform)
-sub info { shift; print STDERR "[INFO] $_[0]\n" }
+sub info { print STDERR "[INFO] $_[1]\n" }
 
 # notice
 # warning (warn)
-sub warn { shift; print STDERR "[WARN] $_[0]\n" }
+sub warn { print STDERR "[WARN] $_[1]\n" }
 
 # error (err)
 # critical (crit, fatal)

--- a/lib/OrePAN2/Role/HasLogger.pm
+++ b/lib/OrePAN2/Role/HasLogger.pm
@@ -1,4 +1,5 @@
 package OrePAN2::Role::HasLogger;
+use OrePAN2::Logger;
 
 use Moo::Role;
 
@@ -9,7 +10,6 @@ has log => (
 );
 
 sub _build_log {
-    require OrePAN2::Logger;
     OrePAN2::Logger->new->get_logger;
 }
 

--- a/lib/OrePAN2/Role/HasLogger.pm
+++ b/lib/OrePAN2/Role/HasLogger.pm
@@ -1,16 +1,13 @@
 package OrePAN2::Role::HasLogger;
-use OrePAN2::Logger;
 
 use Moo::Role;
+
+use OrePAN2::Logger ();
 
 has log => (
     is      => 'ro',
     lazy    => 1,
-    builder => '_build_log',
+    default => sub { OrePAN2::Logger->new },
 );
-
-sub _build_log {
-    OrePAN2::Logger->new->get_logger;
-}
 
 1;

--- a/lib/OrePAN2/Role/HasLogger.pm
+++ b/lib/OrePAN2/Role/HasLogger.pm
@@ -1,0 +1,16 @@
+package OrePAN2::Role::HasLogger;
+
+use Moo::Role;
+
+has log => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_build_log',
+);
+
+sub _build_log {
+    require OrePAN2::Logger;
+    OrePAN2::Logger->new->get_logger;
+}
+
+1;

--- a/t/08_logging.t
+++ b/t/08_logging.t
@@ -26,9 +26,9 @@ subtest 'add_index_default_logger', sub {
         $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
     };
     like $stderr, qr{\[INFO\] Not adding X in X/X/X/X-0.01.tar.gz},
-        'INFO: Not adding to index (via STDERR)';
+        "got 'Not adding to index' via STDERR";
     like $stderr, qr{\[INFO\] Existing version 0.02 is greater than 0.01},
-        'INFO: Existing version greater than new  (via STDERR)';
+        "got 'Existing version greater than new' via STDERR";
 };
 
 subtest 'add_index_log_any', sub {
@@ -52,11 +52,11 @@ subtest 'add_index_log_any', sub {
     $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
     $log->contains_ok(
         qr{Not adding X in X/X/X/X-0.01.tar.gz},
-        "INFO: Not adding to index (via Log::Any)"
+        "got 'Not adding to index' via Log::Any"
     );
     $log->contains_ok(
         qr{Existing version 0.02 is greater than 0.01},
-        "INFO: Existing version greater than new (via Log::Any)"
+        "got 'Existing version greater than new' via Log::Any"
     );
 };
 
@@ -78,10 +78,10 @@ subtest 'add_index_mojo_log', sub {
     $index->add_index( 'X', 0.02, 'X/X/X/X-0.02.tar.gz' );
     $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
     like $messages->[-2], qr{\[info\] Not adding X in X/X/X/X-0.01.tar.gz},
-        'INFO: Not adding to index (via Mojo::Log)';
+        "got 'Not adding to index' via Mojo::Log";
     like $messages->[-1],
         qr{\[info\] Existing version 0.02 is greater than 0.01},
-        'INFO: Existing version greater than new  (via Mojo::Log)';
+        "got 'Existing version greater than new' via Mojo::Log";
 };
 
 done_testing;

--- a/t/08_logging.t
+++ b/t/08_logging.t
@@ -2,13 +2,10 @@ use strict;
 use warnings;
 
 use Test::More;
-use Capture::Tiny (qw /capture/);
-use Log::Any::Test;
-use Log::Any;
+use Test::Needs 'Test::Output';
 
-use OrePAN2::Index ();
+use OrePAN2::Index   ();
 use OrePAN2::Indexer ();
-
 
 subtest 'test_default_logger', sub {
 
@@ -22,13 +19,11 @@ subtest 'test_default_logger', sub {
     $index->add_index( 'X', 0.02, 'X/X/X/X-0.02.tar.gz' );
 
     # Add X-0.01 to index again -> expect logging
-    my ( undef, $stderr, undef ) = Capture::Tiny::capture {
-        $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
-    };
-    like $stderr, qr{\[INFO\] Not adding X in X/X/X/X-0.01.tar.gz},
+    Test::Output::stderr_like {
+        $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' )
+    }
+    qr{\[INFO\] Not adding X in X/X/X/X-0.01.tar.gz},
         "got 'Not adding to index' via STDERR";
-    like $stderr, qr{\[INFO\] Existing version 0.02 is greater than 0.01},
-        "got 'Existing version greater than new' via STDERR";
 
     my $tmpdir = Path::Tiny->tempdir( CLEANUP => 1 );
 
@@ -37,46 +32,8 @@ subtest 'test_default_logger', sub {
         simple    => 1,
     );
 
-    ( undef, $stderr, undef ) = Capture::Tiny::capture {
-        $orepan->log->info("Testing");
-    };
-    like $stderr, qr{\[INFO\] Testing},
-        "got 'Testing' via STDERR";
-
-};
-
-subtest 'test_log_any', sub {
-
-    my $log = Log::Any->get_logger();
-
-    my $index = OrePAN2::Index->new( log => $log );
-
-    $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
-    $index->add_index( 'X', 0.02, 'X/X/X/X-0.02.tar.gz' );
-    $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
-    $log->contains_ok(
-        qr{Not adding X in X/X/X/X-0.01.tar.gz},
-        "got 'Not adding to index' via Log::Any"
-    );
-    $log->contains_ok(
-        qr{Existing version 0.02 is greater than 0.01},
-        "got 'Existing version greater than new' via Log::Any"
-    );
-
-    my $tmpdir = Path::Tiny->tempdir( CLEANUP => 1 );
-
-    my $orepan = OrePAN2::Indexer->new(
-        directory => $tmpdir,
-        simple    => 1,
-        log       => $log,
-    );
-
-    $orepan->log->info("Testing");
-    $log->contains_ok(
-        qr{Testing},
-        "got 'Testing' via Log::Any"
-    );
-
+    Test::Output::stderr_like { $orepan->log->info("Testing") }
+    qr{\[INFO\] Testing}, "got 'Testing' via STDERR";
 };
 
 done_testing;

--- a/t/08_logging.t
+++ b/t/08_logging.t
@@ -1,0 +1,87 @@
+use strict;
+use warnings;
+
+use Test::More;
+use OrePAN2::Index ();
+
+subtest 'add_index_default_logger', sub {
+
+    plan skip_all => 'requires Capture::Tiny'
+        unless eval {
+        use Capture::Tiny ':all';
+        1;
+        };
+
+    # create new index
+    my $index = OrePAN2::Index->new();
+
+    # Add to index: X-0.01
+    $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
+
+    # Add to index: X-0.02
+    $index->add_index( 'X', 0.02, 'X/X/X/X-0.02.tar.gz' );
+
+    # Add X-0.01 to index again -> expect logging
+    my ( undef, $stderr, undef ) = Capture::Tiny::capture {
+        $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
+    };
+    like $stderr, qr{\[INFO\] Not adding X in X/X/X/X-0.01.tar.gz},
+        'INFO: Not adding to index (via STDERR)';
+    like $stderr, qr{\[INFO\] Existing version 0.02 is greater than 0.01},
+        'INFO: Existing version greater than new  (via STDERR)';
+};
+
+subtest 'add_index_log_any', sub {
+
+    plan skip_all => 'requires Log::Any and Log::Any::Test'
+        unless eval {
+        require Log::Any;
+        require Log::Any::Test;
+        1;
+        };
+
+    Log::Any->import;
+    Log::Any::Test->import;
+
+    my $log = Log::Any->get_logger();
+
+    my $index = OrePAN2::Index->new( log => $log );
+
+    $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
+    $index->add_index( 'X', 0.02, 'X/X/X/X-0.02.tar.gz' );
+    $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
+    $log->contains_ok(
+        qr{Not adding X in X/X/X/X-0.01.tar.gz},
+        "INFO: Not adding to index (via Log::Any)"
+    );
+    $log->contains_ok(
+        qr{Existing version 0.02 is greater than 0.01},
+        "INFO: Existing version greater than new (via Log::Any)"
+    );
+};
+
+subtest 'add_index_mojo_log', sub {
+
+    plan skip_all => 'requires Mojo::Log'
+        unless eval {
+        require Mojo::Log;
+        1;
+        };
+
+    Mojo::Log->import;
+
+    my $log      = Mojo::Log->new;
+    my $messages = $log->capture();
+
+    my $index = OrePAN2::Index->new( log => $log );
+    $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
+    $index->add_index( 'X', 0.02, 'X/X/X/X-0.02.tar.gz' );
+    $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
+    like $messages->[-2], qr{\[info\] Not adding X in X/X/X/X-0.01.tar.gz},
+        'INFO: Not adding to index (via Mojo::Log)';
+    like $messages->[-1],
+        qr{\[info\] Existing version 0.02 is greater than 0.01},
+        'INFO: Existing version greater than new  (via Mojo::Log)';
+};
+
+done_testing;

--- a/t/09_log_any.t
+++ b/t/09_log_any.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Needs 'Log::Any::Test', 'Log::Any';
+
+use OrePAN2::Index   ();
+use OrePAN2::Indexer ();
+
+subtest 'test_log_any', sub {
+
+    my $log = Log::Any->get_logger();
+
+    my $index = OrePAN2::Index->new( log => $log );
+
+    $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
+    $index->add_index( 'X', 0.02, 'X/X/X/X-0.02.tar.gz' );
+    $index->add_index( 'X', 0.01, 'X/X/X/X-0.01.tar.gz' );
+    $log->contains_ok(
+        qr{Not adding X in X/X/X/X-0.01.tar.gz},
+        "got 'Not adding to index' via Log::Any"
+    );
+    $log->contains_ok(
+        qr{Existing version 0.02 is greater than 0.01},
+        "got 'Existing version greater than new' via Log::Any"
+    );
+
+    my $tmpdir = Path::Tiny->tempdir( CLEANUP => 1 );
+
+    my $orepan = OrePAN2::Indexer->new(
+        directory => $tmpdir,
+        simple    => 1,
+        log       => $log,
+    );
+
+    $orepan->log->info("Testing");
+    $log->contains_ok(
+        qr{Testing},
+        "got 'Testing' via Log::Any"
+    );
+
+};
+
+done_testing;

--- a/xt/inject-git.t
+++ b/xt/inject-git.t
@@ -11,11 +11,11 @@ no warnings 'redefine';
 
 my @specs = (
     [
-        'git://github.com/tokuhirom/Acme-Foo.git',
+        'https://github.com/tokuhirom/Acme-Foo.git',
         "authors/id/D/DU/DUMMY/Acme-Foo-0.01.tar.gz"
     ],
     [
-        'git://github.com/tokuhirom/Acme-Foo.git@master',
+        'https://github.com/tokuhirom/Acme-Foo.git@master',
         "authors/id/D/DU/DUMMY/Acme-Foo-0.01.tar.gz"
     ],
 );


### PR DESCRIPTION
**Summary**

This pull request introduces logging flexibility to OrePAN2.
While OrePAN2 currently writes all log output directly to `STDERR`, this implementation enables redirection to alternative logging systems, such as `Mojo::Log` or `Log::Any`.

**Background**

* **OrePAN1 vs. OrePAN2:** OrePAN2 is a reimplementation that can be used as a library, making it more versatile.
* **Related tools:** `Mojo::Darkpan` uses OrePAN2 internally but currently cannot receive or process its log output.
* **Current limitation:** Logging is hard-coded to `STDERR`. This change aims to make logging pluggable.

**Notes**

* This pull request is **not complete** — `OrePAN2::Indexer` is not yet handled.
* Additional work is required to provide full coverage across all components.

