### PR TITLE
orepan2-merge-index: add --orepan/--cpan/--protect-orepan-author

### DIFF
--- a/lib/OrePAN2/Index.pm
+++ b/lib/OrePAN2/Index.pm
@@ -85,6 +85,37 @@ sub add_index {
     $self->index->{$package} = [ $version, $archive_file ];
 }
 
+sub merge {
+    my ( $self, $other, %opts ) = @_;
+
+    my %protected_author
+        = map { uc($_) => 1 } grep {length} @{ $opts{protect_author} || [] };
+    my %protected_package;
+    if (%protected_author) {
+        my %matched_author;
+        for my $package ( $self->packages ) {
+            my (undef, $path) = $self->lookup($package);
+            next unless defined $path;
+            my ($author) = $path =~ m{\A[^/]+/[^/]+/([^/]+)/};
+            next unless defined $author && $protected_author{ uc($author) };
+            $protected_package{$package} = 1;
+            $matched_author{ uc($author) } = 1;
+        }
+        for my $author ( sort keys %protected_author ) {
+            $self->log->warn(
+                "protect_author '$author' matched no packages in this index"
+            ) unless $matched_author{$author};
+        }
+    }
+
+    for my $package ( $other->packages ) {
+        next if $protected_package{$package};
+        my ( $version, $archive_file ) = $other->lookup($package);
+        $self->add_index( $package, $version, $archive_file );
+    }
+    return;
+}
+
 sub as_string {
     my ( $self, $opts ) = @_;
     $opts ||= +{};
@@ -165,6 +196,26 @@ Delete a package from the index.
 =item C<< $index->add_index($package, $version, $path) >>
 
 Add a new entry to the index.
+
+=item C<< $index->merge($other_index, protect_author => \@pause_ids) >>
+
+Merge every package from C<$other_index> into C<$index>, in place. Ordinary
+merges use C<add_index>'s "higher version wins" semantics.
+
+C<protect_author> is an optional list of PAUSE ids. Any package already in
+C<$index> whose entry's path is authored by one of these ids (i.e. the path
+looks like C<X/XX/AUTHORID/...>) keeps its C<$index> entry, even if
+C<$other_index> has a numerically higher version of the same package.
+Matching is case-insensitive.
+
+Protection is applied per I<package>, not per I<distribution>: if
+C<$other_index> provides a package that C<$index>'s copy of a protected
+author's distribution doesn't, that package is still taken from
+C<$other_index>.
+
+If a given C<protect_author> id matches zero packages in C<$index> (a typo,
+or nothing from that author is in the index yet), a warning is logged -- it
+doesn't fail the merge, but it means that id currently protects nothing.
 
 =item C<< $index->as_string() >>
 

--- a/script/orepan2-merge-index
+++ b/script/orepan2-merge-index
@@ -4,14 +4,44 @@ use warnings;
 use OrePAN2::Index;
 use Getopt::Long;
 
-my $version;
 my $p = Getopt::Long::Parser->new(
     config => [qw(posix_default no_ignore_case auto_help)]
 );
 $p->getoptions(
-    'o=s' => \my $outfilename,
-    'simple!' => \my $simple,
-);
+    'o=s'                      => \my $outfilename,
+    'simple!'                  => \my $simple,
+    'orepan=s'                 => \my $orepan_file,
+    'cpan=s'                   => \my $cpan_file,
+    'protect-orepan-author=s@' => \my $protected_authors,
+) or die "Usage error\n";
+
+my $merge_mode = defined $orepan_file || defined $cpan_file;
+
+if ($merge_mode) {
+    die "--orepan and --cpan must be given together\n"
+        unless defined $orepan_file && defined $cpan_file;
+    die "stray positional arguments not allowed with --orepan/--cpan: @ARGV\n"
+        if @ARGV;
+}
+elsif ($protected_authors && @$protected_authors) {
+    die "--protect-orepan-author only works with --orepan and --cpan\n";
+}
+
+my $index;
+if ($merge_mode) {
+    $index = OrePAN2::Index->new();
+    $index->load($orepan_file, {replace => 1});
+
+    my $cpan_index = OrePAN2::Index->new();
+    $cpan_index->load($cpan_file, {replace => 1});
+    $index->merge($cpan_index, protect_author => $protected_authors || []);
+}
+else {
+    $index = OrePAN2::Index->new();
+    for my $filename (@ARGV) {
+        $index->load($filename, {replace => 1});
+    }
+}
 
 my $outfh = *STDOUT;
 if (defined $outfilename) {
@@ -19,17 +49,23 @@ if (defined $outfilename) {
         or die "Cannot open $outfilename for writing: $!";
 }
 
-my $index = OrePAN2::Index->new();
-for my $filename (@ARGV) {
-    $index->load($filename, {replace => 1});
-}
-print {$outfh} $index->as_string({simple => $simple});
+my $outname = defined $outfilename ? $outfilename : 'STDOUT';
+print {$outfh} $index->as_string({simple => $simple})
+    or die "Cannot write to $outname: $!\n";
+close $outfh
+    or die "Cannot close $outname: $!\n";
 
 __END__
 
 =head1 SYNOPSIS
 
     % orepan2-merge-index -o merged.txt foo/02packages.details.txt bar/02packages.details.txt.gz
+
+    % orepan2-merge-index -o merged.txt \
+        --orepan orepan/02packages.details.txt.gz \
+        --cpan cpan/02packages.details.txt.gz \
+        --protect-orepan-author DUMMY \
+        --protect-orepan-author WATERKIP
 
 =head1 DESCRIPTION
 
@@ -52,5 +88,36 @@ Name of output file
 Use a simple format for 02packages metadata.  This helps avoid merge conflicts.
 
      > orepan2-merge-index --simple -o merged.txt foo/02packages.details.txt bar/02packages.details.txt.gz
+
+=head2 orepan / cpan
+
+    % orepan2-merge-index -o merged.txt --orepan orepan/02packages.details.txt.gz --cpan cpan/02packages.details.txt.gz
+
+Merge a darkpan's own index (C<--orepan>) with a CPAN mirror's index
+(C<--cpan>). Without C<--protect-orepan-author>, this behaves like the
+positional-file mode: the higher version of each package wins.
+
+Only meaningful together; specifying one without the other is an error, as
+is passing any stray positional arguments alongside them.
+
+=head2 protect-orepan-author
+
+    % orepan2-merge-index -o merged.txt --orepan o.txt --cpan c.txt \
+        --protect-orepan-author DUMMY --protect-orepan-author WATERKIP
+
+Repeatable. Any package whose C<--orepan> index entry's path is authored
+by one of these PAUSE ids (i.e. the path looks like C<X/XX/AUTHORID/...>)
+always keeps its C<--orepan> entry, even if C<--cpan> has a higher
+version for the same package. Matching is case-insensitive.
+
+Only usable together with C<--orepan> and C<--cpan>; it's an error to pass
+it in positional-file mode, since protection isn't implemented there.
+
+Protection is applied per I<package>, not per I<distribution>: if CPAN's
+copy of a protected author's distribution provides a package the
+C<--orepan> copy doesn't, that package is still taken from CPAN.
+
+A path not shaped like C<X/XX/AUTHORID/...> (e.g. a flat filename) has no
+extractable author and so can never match, regardless of this option.
 
 =cut

--- a/t/cli/merge-index-protect-errors.t
+++ b/t/cli/merge-index-protect-errors.t
@@ -1,0 +1,168 @@
+use strict;
+use warnings;
+use utf8;
+
+use File::Temp qw( SEEK_SET );
+use Test::More;
+
+my $SCRIPT = 'script/orepan2-merge-index';
+
+sub write_index {
+    my (@lines) = @_;
+    my $fh = File::Temp->new;
+    print {$fh} <<'...';
+File:         02packages.details.txt
+Columns:      package name, version, path
+
+...
+    print {$fh} "$_\n" for @lines;
+    $fh->close;
+    return $fh;
+}
+
+sub run_merge {
+    my (@args) = @_;
+    my $status = system $^X, '-Ilib', $SCRIPT, @args;
+    return $status >> 8;
+}
+
+sub slurp {
+    my ($file) = @_;
+    open my $fh, '<', $file or die "Cannot read $file: $!";
+    return do { local $/; <$fh> };
+}
+
+my @OREPAN = (
+    'Foo::Bar               0.01                   D/DU/DUMMY/Foo-Bar-0.01.tar.gz',
+);
+my @CPAN = (
+    'Foo::Bar               2.00                   C/CP/CPANAUTH/Foo-Bar-2.00.tar.gz',
+);
+
+subtest '-o file is not clobbered when --orepan/--cpan pairing check fails' => sub {
+    my $orepan = write_index(@OREPAN);
+
+    my $out = File::Temp->new;
+    print {$out} "PRECIOUS EXISTING INDEX\n";
+    $out->close;
+
+    isnt run_merge( '-o', $out->filename, '--orepan', $orepan->filename ), 0,
+        'exits non-zero on --orepan without --cpan';
+
+    is slurp( $out->filename ), "PRECIOUS EXISTING INDEX\n",
+        'the pre-existing output file is left untouched';
+};
+
+subtest '--protect-orepan-author in positional mode is a usage error' => sub {
+    my $orepan = write_index(@OREPAN);
+    my $cpan   = write_index(@CPAN);
+    my $out    = File::Temp->new;
+
+    isnt run_merge(
+        '-o', $out->filename,
+        '--protect-orepan-author', 'DUMMY',
+        $orepan->filename, $cpan->filename,
+        ),
+        0,
+        'refuses to silently ignore the flag in positional mode';
+};
+
+subtest 'author ids are matched case-insensitively' => sub {
+    my $orepan = write_index(@OREPAN);
+    my $cpan   = write_index(@CPAN);
+    my $out    = File::Temp->new;
+
+    is run_merge(
+        '-o', $out->filename,
+        '--orepan', $orepan->filename,
+        '--cpan',   $cpan->filename,
+        '--protect-orepan-author', 'dummy',
+        ),
+        0,
+        'runs successfully';
+
+    my $result = slurp( $out->filename );
+    note $result;
+
+    like $result, qr{Foo::Bar\s+0\.01\s+D/DU/DUMMY},
+        'lower-case author id still protects the package';
+};
+
+subtest 'stray positional arguments are rejected' => sub {
+    my $orepan = write_index(@OREPAN);
+    my $cpan   = write_index(@CPAN);
+    my $extra  = write_index(
+        'Extra::Package         1.00                   E/EX/EXTRA/Extra-Package-1.00.tar.gz'
+    );
+    my $out = File::Temp->new;
+
+    isnt run_merge(
+        '-o', $out->filename,
+        '--orepan', $orepan->filename,
+        '--cpan',   $cpan->filename,
+        $extra->filename,
+        ),
+        0,
+        'refuses to silently drop the leftover positional argument';
+};
+
+subtest '-o file is not clobbered when an input file cannot be read' => sub {
+    my $orepan = write_index(@OREPAN);
+
+    my $out = File::Temp->new;
+    print {$out} "PRECIOUS EXISTING INDEX\n";
+    $out->close;
+
+    isnt run_merge(
+        '-o', $out->filename,
+        '--orepan', $orepan->filename,
+        '--cpan',   '/nonexistent/path/to/02packages.details.txt.gz',
+        ),
+        0,
+        'exits non-zero when an input index cannot be read';
+
+    is slurp( $out->filename ), "PRECIOUS EXISTING INDEX\n",
+        'the pre-existing output file is left untouched';
+};
+
+subtest 'an unrecognised option is a usage error' => sub {
+    my $orepan = write_index(@OREPAN);
+    my $cpan   = write_index(@CPAN);
+
+    my $out = File::Temp->new;
+    print {$out} "PRECIOUS EXISTING INDEX\n";
+    $out->close;
+
+    isnt run_merge(
+        '-o', $out->filename,
+        '--bogus-option',
+        '--orepan', $orepan->filename,
+        '--cpan',   $cpan->filename,
+        ),
+        0,
+        'exits non-zero on an unrecognised option';
+
+    is slurp( $out->filename ), "PRECIOUS EXISTING INDEX\n",
+        'the pre-existing output file is left untouched';
+};
+
+subtest 'write failures on the output file are fatal' => sub {
+    plan skip_all => '/dev/full not available'
+        unless -w '/dev/full';
+
+    my $orepan = write_index(@OREPAN);
+    my $cpan   = write_index(@CPAN);
+
+    # open() succeeds; the print fails. Indexer::write_index checks both
+    # print and close (lib/OrePAN2/Indexer.pm); this script checks neither,
+    # and never closes $outfh at all.
+    isnt run_merge(
+        '-o', '/dev/full',
+        '--orepan', $orepan->filename,
+        '--cpan',   $cpan->filename,
+        ),
+        0,
+        'exits non-zero when the index cannot be written';
+};
+
+done_testing;

--- a/t/cli/merge-index-protect.t
+++ b/t/cli/merge-index-protect.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+use utf8;
+
+use File::Temp qw( SEEK_SET );
+use Test::More;
+
+my $orepan = File::Temp->new();
+print {$orepan} <<'...';
+File:         02packages.details.txt
+Columns:      package name, version, path
+
+Foo::Bar               0.01                   D/DU/DUMMY/Foo-Bar-0.01.tar.gz
+Baz::Qux               0.05                   W/WA/WATERKIP/Baz-Qux-0.05.tar.gz
+Unowned::Thing         0.02                   Z/ZZ/OTHER/Unowned-Thing-0.02.tar.gz
+...
+$orepan->close;
+
+my $cpan = File::Temp->new();
+print {$cpan} <<'...';
+File:         02packages.details.txt
+Columns:      package name, version, path
+
+Foo::Bar               2.00                   C/CP/CPANAUTH/Foo-Bar-2.00.tar.gz
+Baz::Qux               9.00                   C/CP/CPANAUTH/Baz-Qux-9.00.tar.gz
+Unowned::Thing         0.03                   C/CP/CPANAUTH/Unowned-Thing-0.03.tar.gz
+New::Package           1.00                   C/CP/CPANAUTH/New-Package-1.00.tar.gz
+...
+$cpan->close;
+
+my $out = File::Temp->new();
+is system(
+    $^X, '-Ilib', 'script/orepan2-merge-index',
+    '-o', $out->filename,
+    '--orepan', $orepan->filename,
+    '--cpan',   $cpan->filename,
+    '--protect-orepan-author', 'DUMMY',
+    '--protect-orepan-author', 'WATERKIP',
+    ),
+    0;
+$out->seek( 0, SEEK_SET );
+my $result = do { local $/; <$out> };
+note $result;
+
+like $result, qr/Foo::Bar\s+0\.01\s+D\/DU\/DUMMY/,
+    'protected DUMMY package keeps its orepan version';
+like $result, qr/Baz::Qux\s+0\.05\s+W\/WA\/WATERKIP/,
+    'protected WATERKIP package keeps its orepan version';
+like $result, qr/Unowned::Thing\s+0\.03\s+C\/CP\/CPANAUTH/,
+    'unprotected package still takes the higher CPAN version';
+like $result, qr/New::Package\s+1\.00\s+C\/CP\/CPANAUTH/,
+    'CPAN-only package is added';
+
+done_testing;

--- a/t/index.t
+++ b/t/index.t
@@ -43,6 +43,62 @@ subtest 'add_index', sub {
     is [ $index->lookup('X') ]->[1], 'X/X/X/X-0.02.tar.gz';
 };
 
+subtest 'merge' => sub {
+    subtest 'higher version wins with no protect_author' => sub {
+        my $index = OrePAN2::Index->new;
+        $index->add_index( 'Foo::Bar', '0.01', 'D/DU/DUMMY/Foo-Bar-0.01.tar.gz' );
+
+        my $other = OrePAN2::Index->new;
+        $other->add_index( 'Foo::Bar', '2.00', 'C/CP/CPANAUTH/Foo-Bar-2.00.tar.gz' );
+
+        $index->merge($other);
+        is [ $index->lookup('Foo::Bar') ]->[1],
+            'C/CP/CPANAUTH/Foo-Bar-2.00.tar.gz';
+    };
+
+    subtest 'protect_author keeps the lower version' => sub {
+        my $index = OrePAN2::Index->new;
+        $index->add_index( 'Foo::Bar', '0.01', 'D/DU/DUMMY/Foo-Bar-0.01.tar.gz' );
+
+        my $other = OrePAN2::Index->new;
+        $other->add_index( 'Foo::Bar', '2.00', 'C/CP/CPANAUTH/Foo-Bar-2.00.tar.gz' );
+
+        $index->merge( $other, protect_author => ['dummy'] );
+        is [ $index->lookup('Foo::Bar') ]->[1],
+            'D/DU/DUMMY/Foo-Bar-0.01.tar.gz',
+            'matches case-insensitively';
+    };
+
+    subtest 'protection is per-package, not per-distribution' => sub {
+        my $index = OrePAN2::Index->new;
+        $index->add_index( 'Foo::Bar', '0.01', 'D/DU/DUMMY/Foo-Bar-0.01.tar.gz' );
+
+        my $other = OrePAN2::Index->new;
+        $other->add_index( 'Foo::Bar', '2.00', 'C/CP/CPANAUTH/Foo-Bar-2.00.tar.gz' );
+        $other->add_index( 'Foo::Baz', '1.00', 'C/CP/CPANAUTH/Foo-Bar-2.00.tar.gz' );
+
+        $index->merge( $other, protect_author => ['DUMMY'] );
+        is [ $index->lookup('Foo::Bar') ]->[1],
+            'D/DU/DUMMY/Foo-Bar-0.01.tar.gz';
+        is [ $index->lookup('Foo::Baz') ]->[1],
+            'C/CP/CPANAUTH/Foo-Bar-2.00.tar.gz';
+    };
+
+    subtest 'unmatched protect_author warns, does not die' => sub {
+        my $index = OrePAN2::Index->new;
+        $index->add_index( 'Foo::Bar', '2.00', 'C/CP/CPANAUTH/Foo-Bar-2.00.tar.gz' );
+
+        my $stderr = do {
+            open my $fh, '>', \my $captured or die $!;
+            local *STDERR = $fh;
+            eval { $index->merge( OrePAN2::Index->new, protect_author => ['NOBODY'] ) };
+            $captured;
+        };
+        is $@, '', 'does not die';
+        like $stderr, qr/NOBODY/, 'warns about the unmatched author';
+    };
+};
+
 subtest 'delete' => sub {
     my $index = OrePAN2::Index->new;
     $index->load('t/dat/02.packages.details.txt');


### PR DESCRIPTION
 Lets specific darkpan authors' packages keep control over the merged
 index even when CPAN has a numerically higher version for the same
 package name, while leaving normal version-wins behavior for everyone
 else.